### PR TITLE
Abstract over ZMXClient to propery test ZMXTab

### DIFF
--- a/src/zio/zmx_client.rs
+++ b/src/zio/zmx_client.rs
@@ -7,44 +7,85 @@ use tokio::net::TcpStream;
 use crate::zio::dump_parser;
 use crate::zio::model::Fiber;
 
-#[tokio::main]
-pub async fn get_dump(addr: &str) -> Result<Vec<Fiber>, Box<dyn Error>> {
-    let frame = Frame::Array(vec![Frame::BulkString("dump".into())]);
-    let mut buf = BytesMut::new();
+pub trait ZMXClient {
+    fn address(&self) -> String;
+    fn dump_fibers(&self) -> Result<Vec<Fiber>, String>;
+}
 
-    let _ = match redis_protocol::prelude::encode_bytes(&mut buf, &frame) {
-        Ok(l) => l,
-        Err(e) => panic!("Error encoding frame: {:?}", e)
-    };
+pub struct NetworkZMXClient {
+    address: String
+}
 
-    let mut stream = TcpStream::connect(addr).await?;
+impl NetworkZMXClient {
+    pub fn new(address: String) -> NetworkZMXClient { NetworkZMXClient { address } }
 
-    let _ = stream.write(&buf).await;
+    #[tokio::main]
+    async fn get_dump(&self) -> Result<Vec<Fiber>, Box<dyn Error>> {
+        let frame = Frame::Array(vec![Frame::BulkString("dump".into())]);
+        let mut buf = BytesMut::new();
 
-    let mut buffer = String::new();
-    stream.read_to_string(&mut buffer).await?;
+        let _ = match redis_protocol::prelude::encode_bytes(&mut buf, &frame) {
+            Ok(l) => l,
+            Err(e) => panic!("Error encoding frame: {:?}", e)
+        };
 
-    let buf: BytesMut = buffer.into();
+        let mut stream = TcpStream::connect(&self.address).await?;
 
-    let (frame, consumed) = match redis_protocol::prelude::decode_bytes(&buf) {
-        Ok((f, c)) => (f, c),
-        Err(e) => panic!("Error parsing bytes: {:?}", e)
-    };
+        let _ = stream.write(&buf).await;
 
-    let mut fibers: Vec<Fiber> = vec![];
+        let mut buffer = String::new();
+        stream.read_to_string(&mut buffer).await?;
 
-    if let Some(Frame::Array(frames)) = frame {
-        let v: Vec<Fiber> = frames.iter().map(|f| {
-            let dump = f.as_str().unwrap();
-            dump_parser::parse_fiber_dump(dump.to_string()).unwrap()
-        }).collect();
-        v.iter().for_each(|f| {
-            fibers.push(f.to_owned());
-            ()
-        });
-    } else {
-        println!("Incomplete frame, parsed {} bytes", consumed);
+        let buf: BytesMut = buffer.into();
+
+        let (frame, consumed) = match redis_protocol::prelude::decode_bytes(&buf) {
+            Ok((f, c)) => (f, c),
+            Err(e) => panic!("Error parsing bytes: {:?}", e)
+        };
+
+        let mut fibers: Vec<Fiber> = vec![];
+
+        if let Some(Frame::Array(frames)) = frame {
+            let v: Vec<Fiber> = frames.iter().map(|f| {
+                let dump = f.as_str().unwrap();
+                dump_parser::parse_fiber_dump(dump.to_string()).unwrap()
+            }).collect();
+            v.iter().for_each(|f| {
+                fibers.push(f.to_owned());
+                ()
+            });
+        } else {
+            println!("Incomplete frame, parsed {} bytes", consumed);
+        }
+
+        Ok(fibers)
+    }
+}
+
+impl ZMXClient for NetworkZMXClient {
+    fn address(&self) -> String {
+        self.address.clone()
     }
 
-    Ok(fibers)
+    fn dump_fibers(&self) -> Result<Vec<Fiber>, String> {
+        self.get_dump().map_err(|e| e.to_string())
+    }
+}
+
+pub struct StubZMXClient {
+    pub dump: Result<Vec<Fiber>, String>
+}
+
+impl StubZMXClient {
+    pub fn new(dump: Result<Vec<Fiber>, String>) -> StubZMXClient { StubZMXClient { dump } }
+}
+
+impl ZMXClient for StubZMXClient {
+    fn address(&self) -> String {
+        "<stub>".to_owned()
+    }
+
+    fn dump_fibers(&self) -> Result<Vec<Fiber>, String> {
+        self.dump.clone()
+    }
 }


### PR DESCRIPTION
This is a POC of how we can use rust trait objects to improve testability.

In this particular case I managed to abstract `ZMXTab` over `ZMXClient`, so that I can use a stub in tests.