### PR TITLE
Make ZMX tab optional. Improve help and readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,23 +3,55 @@
 Terminal UI diagnostic tool.
 
 Currently supports:
-- ZIO-ZMX
+- [ZIO-ZMX](https://github.com/zio/zio-zmx)
+- [Slick + HikariCP](https://scala-slick.org/doc/3.2.0/config.html#monitoring) (over JMX)
 
-## build
+## Usage
 
-for dev build
+The only way to run Panopticon currently is to build it from sources:
+```
+cargo build
+./target/debug/panopticon-tui [OPTIONS]
+```
+
+To get a detailed help message, run:
+```
+panopticon-tui --help
+```
+
+Currently, Panopticon UI is using tabs. Tabs you going to see depend on what options you use to launch Panopticon (see further).
+
+### Connecting to zio-zmx server
+
+[ZIO-ZMX](https://github.com/zio/zio-zmx) is a tool for monitoring ZIO-based apps.
+You can specify zio-zmx server address with `--zio-zmx` option. In this case Panopticon will connect to it and show a ZMX tab:
+```
+panopticon-tui --zio-zmx localhost:6789
+```
+
+### Database metrics over JMX
+
+Panopticon can show database metrics, if your app exposes them via JMX. Slick and HikariCP are the only supported options at the moment.
+
+Slick tab will be shown in Panopticon if you specify these two options:
+
+```
+panopticon-tui --jmx localhost:9010 --db-pool-name myDb
+```
+
+Here `db-pool-name` is a connection pool name, used to qualify JMX beans for Slick and/or HikariCP. 
+
+See [this section](https://scala-slick.org/doc/3.2.0/config.html#monitoring) of Slick docs for details about setting up your app to expose db metrics over JMX.
+
+
+## Build from sources
+
+Development build:
 ```
 cargo build
 ```
 
-for optimized release build
+Optimized release build:
 ```
 cargo build --release
-```
-
-## run
-
-To run it you need to pass an addresses of ZIO-ZMX server:
-```
-./target/debug/panopticon-tui -zio-zmx localhost:1111
 ```

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -201,15 +201,19 @@ pub struct App<'a> {
     pub title: &'a str,
     pub should_quit: bool,
     pub tabs: TabsState<'a>,
-    pub zmx: ZMXTab<'a>,
+    pub zmx: Option<ZMXTab<'a>>,
     pub jmx_settings: Option<JMXConnectionSettings>,
     pub jmx_connection_error: Option<String>,
     pub slick: Option<SlickTab>,
 }
 
 impl<'a> App<'a> {
-    pub fn new(title: &'a str, zio_zmx_addr: String, jmx: Option<JMXConnectionSettings>) -> App<'a> {
-        let mut tabs: Vec<Tab> = vec![Tab { kind: TabKind::ZMX, title: "ZMX" }];
+    pub fn new(title: &'a str, zio_zmx_addr: Option<String>, jmx: Option<JMXConnectionSettings>) -> App<'a> {
+        let mut tabs: Vec<Tab> = vec![];
+
+        if let Some(_) = zio_zmx_addr {
+            tabs.push(Tab { kind: TabKind::ZMX, title: "ZMX" })
+        }
 
         if let Some(_) = jmx {
             tabs.push(Tab { kind: TabKind::Slick, title: "Slick" })
@@ -219,7 +223,7 @@ impl<'a> App<'a> {
             title,
             should_quit: false,
             tabs: TabsState::new(tabs),
-            zmx: ZMXTab::new(zio_zmx_addr),
+            zmx: zio_zmx_addr.map(|x| ZMXTab::new(x)),
             jmx_settings: jmx,
             jmx_connection_error: Some("Not connected yet".to_owned()),
             slick: None,
@@ -259,14 +263,14 @@ impl<'a> App<'a> {
 
     pub fn on_up(&mut self) {
         match self.tabs.current().kind {
-            TabKind::ZMX => self.zmx.select_prev_fiber(),
+            TabKind::ZMX => self.zmx.as_mut().unwrap().select_prev_fiber(),
             TabKind::Slick => {}
         }
     }
 
     pub fn on_down(&mut self) {
         match self.tabs.current().kind {
-            TabKind::ZMX => self.zmx.select_next_fiber(),
+            TabKind::ZMX => self.zmx.as_mut().unwrap().select_next_fiber(),
             TabKind::Slick => {}
         }
     }
@@ -281,7 +285,7 @@ impl<'a> App<'a> {
 
     pub fn on_enter(&mut self) {
         match self.tabs.current().kind {
-            TabKind::ZMX => self.zmx.dump_fibers(),
+            TabKind::ZMX => self.zmx.as_mut().unwrap().dump_fibers(),
             TabKind::Slick => self.connect_to_jmx()
         }
     }
@@ -297,22 +301,24 @@ impl<'a> App<'a> {
 
     pub fn on_page_up(&mut self) {
         match self.tabs.current().kind {
-            TabKind::ZMX => self.zmx.scroll_up(),
+            TabKind::ZMX => self.zmx.as_mut().unwrap().scroll_up(),
             TabKind::Slick => {}
         }
     }
 
     pub fn on_page_down(&mut self) {
         match self.tabs.current().kind {
-            TabKind::ZMX => self.zmx.scroll_down(),
+            TabKind::ZMX => self.zmx.as_mut().unwrap().scroll_down(),
             TabKind::Slick => {}
         }
     }
 
     pub fn on_tick(&mut self) {
-        self.zmx.tick();
-        if let Some(s) = &mut self.slick {
-            s.tick();
+        if let Some(t) = &mut self.zmx {
+            t.tick();
+        }
+        if let Some(r) = &mut self.slick {
+            r.tick();
         }
     }
 }

--- a/src/ui/ui.rs
+++ b/src/ui/ui.rs
@@ -29,7 +29,7 @@ pub fn draw<B: Backend>(terminal: &mut Terminal<B>, app: &App) -> Result<(), io:
             .select(app.tabs.index)
             .render(&mut f, chunks[0]);
         match app.tabs.current().kind {
-            TabKind::ZMX => draw_zio_tab(&mut f, &app.zmx, chunks[1]),
+            TabKind::ZMX => draw_zio_tab(&mut f, &app.zmx.as_ref().unwrap(), chunks[1]),
             TabKind::Slick => draw_slick_tab(&mut f, &app.slick.as_ref().unwrap(), chunks[1]),
         };
     })

--- a/src/zio/tests.rs
+++ b/src/zio/tests.rs
@@ -1,8 +1,8 @@
-use crate::zio::dump_parser::parse_fiber_dump;
-use crate::zio::model::{Fiber, FiberStatus};
-
 #[test]
 fn dump_parser_done() {
+    use crate::zio::dump_parser::parse_fiber_dump;
+    use crate::zio::model::{Fiber, FiberStatus};
+
     let dump = "#4 (7h432m25965s25965835ms)
     Status: Done()";
 
@@ -17,6 +17,9 @@ fn dump_parser_done() {
 
 #[test]
 fn dump_parser_suspended_with_parent() {
+    use crate::zio::dump_parser::parse_fiber_dump;
+    use crate::zio::model::{Fiber, FiberStatus};
+
     let dump = "#2 (1m98s98260ms) waiting on #2
     Status: Suspended(interruptible, 18 asyncs, zio.Promise.await(Promise.scala:50))
     <something>
@@ -34,6 +37,9 @@ fn dump_parser_suspended_with_parent() {
 
 #[test]
 fn dump_parser_running() {
+    use crate::zio::dump_parser::parse_fiber_dump;
+    use crate::zio::model::{Fiber, FiberStatus};
+
     let dump = "#3 (1m96s96402ms)
     Status: Running()";
 
@@ -48,6 +54,9 @@ fn dump_parser_running() {
 
 #[test]
 fn dump_parser_finishing() {
+    use crate::zio::dump_parser::parse_fiber_dump;
+    use crate::zio::model::{Fiber, FiberStatus};
+
     let dump = "#3 (1m96s96402ms)
     Status: Finishing()";
 
@@ -62,6 +71,7 @@ fn dump_parser_finishing() {
 
 #[test]
 fn dump_parser_unknown_status() {
+    use crate::zio::dump_parser::parse_fiber_dump;
     let dump = "#3 (1m96s96402ms)
     Status: Trolling()";
 
@@ -70,6 +80,7 @@ fn dump_parser_unknown_status() {
 
 #[test]
 fn dump_parser_not_enough_lines() {
+    use crate::zio::dump_parser::parse_fiber_dump;
     assert_eq!(parse_fiber_dump("#3 (1m96s96402ms)".to_owned()), None);
     assert_eq!(parse_fiber_dump("".to_owned()), None);
 }


### PR DESCRIPTION
Fix #10.

Now if some parameters aren't valid, or there's no tab to show - we print a help message instead of panicking.
