### PR TITLE
Show real fiber count by status using regular fiber dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ You can specify zio-zmx server address with `--zio-zmx` option. In this case Pan
 panopticon-tui --zio-zmx localhost:6789
 ```
 
+**⚠️ WARNING**: Currently, zio-zmx doesn't provide efficient ways of getting fiber count metrics, so Panopticon has to do a full fiber dump each tick to calculate them. Make sure your `tick-rate` isn't too frequent.
+
 ### Database metrics over JMX
 
 Panopticon can show database metrics, if your app exposes them via JMX. Slick and HikariCP are the only supported options at the moment.

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,8 @@ enum Event<I> {
 /// - jmx + db-pool-name
 #[derive(Debug, StructOpt)]
 struct Cli {
-    /// Frequency to use for fetching metrics
+    /// Frequency (in ms) to use for fetching metrics.
+    /// Don't set this too low, because currently zmx tab does a full fiber dump every tick
     #[structopt(long = "tick-rate", default_value = "2000")]
     tick_rate: u64,
     /// Address of zio-zmx server, e.g. localhost:6789

--- a/src/zio/model.rs
+++ b/src/zio/model.rs
@@ -27,3 +27,17 @@ impl Display for FiberStatus {
         write!(f, "{:?}", self)
     }
 }
+
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+pub struct FiberCount {
+    pub done: i32,
+    pub finishing: i32,
+    pub running: i32,
+    pub suspended: i32,
+}
+
+impl FiberCount {
+    pub fn total(&self) -> i32 {
+        self.done + self.finishing + self.running + self.suspended
+    }
+}


### PR DESCRIPTION
Now looks like this:
![image](https://user-images.githubusercontent.com/410508/81379450-d1e2e180-9111-11ea-97d3-d7cf492a42dd.png)

Added warnings about regular fiber dumps to both `--help` and readme.
