### PR TITLE
Add akka cluster status panel

### DIFF
--- a/src/akka/client.rs
+++ b/src/akka/client.rs
@@ -89,8 +89,8 @@ async fn get_akka_cluster_status_async(url: &String) -> Result<Vec<ClusterMember
     if response.status().is_success() {
         let response_body: HashMap<String, Value> = response.json().await.map_err(|e| e.to_string())?;
         if let Some(w) = response_body.get("members") {
-            let u: Vec<ClusterMember> = serde_json::from_value(w.to_owned()).unwrap();
-            Ok(u)
+            let members: Vec<ClusterMember> = serde_json::from_value(w.to_owned()).unwrap();
+            Ok(members)
         } else {
             Err(format!("Request to get cluster status failed while deserializing"))
         }

--- a/src/akka/client.rs
+++ b/src/akka/client.rs
@@ -92,7 +92,7 @@ async fn get_akka_cluster_status_async(url: &String) -> Result<Vec<ClusterMember
             let members: Vec<ClusterMember> = serde_json::from_value(w.to_owned()).unwrap();
             Ok(members)
         } else {
-            Err(format!("Request to get cluster status failed while deserializing"))
+            Err(format!("Request to get cluster status failed while deserializing, response body is: {:?}", response_body))
         }
     } else {
         Err(format!("Request to get cluster status failed with status {}", response.status()))

--- a/src/akka/model.rs
+++ b/src/akka/model.rs
@@ -8,6 +8,7 @@ pub struct AkkaSettings {
     pub tree_address: String,
     pub status_address: String,
     pub dead_letters_address: String,
+    pub cluster_status_address: Option<String>,
     pub tree_timeout: u64,
     pub status_timeout: u64,
     pub dead_letters_window: u64,
@@ -95,6 +96,15 @@ pub struct ActorSystemStatus {
     pub uptime: u64,
     #[serde(rename(deserialize = "startTime"))]
     pub start_time: u64,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ClusterMember {
+    pub node: String,
+    #[serde(rename(deserialize = "nodeUid"))]
+    pub node_uid: String,
+    pub status: String,
+    pub roles: Vec<String>
 }
 
 

--- a/src/akka/model.rs
+++ b/src/akka/model.rs
@@ -1,6 +1,7 @@
 extern crate chrono;
 
 use chrono::prelude::*;
+use std::fmt;
 use serde::Deserialize;
 
 #[derive(Clone)]
@@ -173,5 +174,11 @@ impl DeadLettersUIMessage {
 
     pub fn readable_timestamp(&self) -> NaiveDateTime {
         NaiveDateTime::from_timestamp((self.timestamp / 1000) as i64, 0)
+    }
+}
+
+impl fmt::Display for ClusterMember {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "id: {}, status: {}", self.node_uid, self.status)
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -212,7 +212,7 @@ impl AkkaTab {
     pub const MAX_ACTOR_COUNT_MEASURES: usize = 25;
     pub const MAX_DEAD_LETTERS_WINDOW_MEASURES: usize = 100;
 
-    pub fn new() -> AkkaTab {
+    pub fn new(is_cluster_enabled: bool) -> AkkaTab {
         AkkaTab {
             actors: StatefulList::with_items(vec![]),
             actor_counts: VecDeque::new(),
@@ -236,7 +236,7 @@ impl AkkaTab {
                 uptime: 0,
                 start_time: 0,
             },
-            cluster_status: None,
+            cluster_status: if is_cluster_enabled { Some(vec![]) } else { None },
         }
     }
 
@@ -377,7 +377,7 @@ impl<'a> App<'a> {
             tabs: TabsState::new(tabs),
             zmx: zio_zmx_addr.map(|_| ZMXTab::new()),
             slick: jmx.map(|_| SlickTab::new()),
-            akka: akka.map(|_| AkkaTab::new()),
+            akka: akka.map(|akka| AkkaTab::new(akka.cluster_status_address.is_some())),
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,7 @@ use std::iter::Iterator;
 
 use tui::widgets::ListState;
 
-use crate::akka::model::{ActorTreeNode, AkkaSettings, DeadLettersSnapshot, DeadLettersWindow, DeadLettersUIMessage, ActorSystemStatus};
+use crate::akka::model::{ActorTreeNode, AkkaSettings, DeadLettersSnapshot, DeadLettersWindow, DeadLettersUIMessage, ActorSystemStatus, ClusterMember};
 use crate::jmx::model::{HikariMetrics, JMXConnectionSettings, SlickConfig, SlickMetrics};
 use crate::widgets::tree;
 use crate::zio::model::{Fiber, FiberCount, FiberStatus};
@@ -201,6 +201,7 @@ pub struct AkkaTab {
     pub actors: StatefulList<String>,
     pub actor_counts: VecDeque<u64>,
     pub system_status: ActorSystemStatus,
+    pub cluster_status: Option<Vec<ClusterMember>>,
     pub dead_letters_messages: DeadLettersSnapshot,
     pub dead_letters_windows: VecDeque<DeadLettersWindow>,
     pub dead_letters_tabs: TabsState<DeadLettersTabKind>,
@@ -235,6 +236,7 @@ impl AkkaTab {
                 uptime: 0,
                 start_time: 0,
             },
+            cluster_status: None,
         }
     }
 
@@ -283,6 +285,10 @@ impl AkkaTab {
         };
 
         self.dead_letters_log = StatefulList::with_items(ui_messages)
+    }
+
+    pub fn update_cluster_status(&mut self, v: Vec<ClusterMember>) {
+        self.cluster_status = Some(v)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,6 @@ fn main() -> Result<(), failure::Error> {
 
     let tick_rate = Duration::from_millis(cli.tick_rate);
     let has_jmx = cli.jmx_settings().is_some();
-    let is_cluster_enabled: bool = cli.akka_settings().map(|s| s.cluster_status_address.is_some()).unwrap_or(false);
 
     enable_raw_mode()?;
 
@@ -324,17 +323,12 @@ fn main() -> Result<(), failure::Error> {
                     None => {}
                 }
 
-                if app.akka.is_some() {
+                if let Some(akka) = app.akka.as_ref() {
                     txf.send(FetcherRequest::ActorSystemStatus)?;
                     txf.send(FetcherRequest::DeadLetters)?;
-                    if is_cluster_enabled {
+                    if akka.cluster_status.is_some() {
                         txf.send(FetcherRequest::ClusterStatus)?;
                     }
-                    // match cli.akka_settings() {
-                    //     Some(AkkaSettings { cluster_status_address: Some(_), .. }) =>
-                    //         txf.send(FetcherRequest::ClusterStatus)?,
-                    //     _ => (),
-                    // }
                 }
             }
         }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -586,6 +586,5 @@ fn draw_cluster_status<B>(f: &mut Frame<B>, v: &Vec<ClusterMember>, area: Rect)
             .borders(Borders::ALL)
             .title_style(Style::default().fg(Color::Cyan))
             .title("Cluster nodes"));
-
     f.render_widget(list, area);
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -377,13 +377,15 @@ fn draw_akka_tab<B>(f: &mut Frame<B>, tab: &mut AkkaTab, area: Rect)
                 .direction(Direction::Horizontal)
                 .split(chunks[0]);
             {
-                let chunks = Layout::default()
-                    .constraints([Constraint::Percentage(30), Constraint::Percentage(70)].as_ref())
-                    .direction(Direction::Vertical)
-                    .split(chunks[1]);
-                draw_actor_count_chart(f, tab, chunks[0]);
                 if let Some(members) = &tab.cluster_status {
-                    draw_cluster_status(f, members, chunks[1])
+                    let chunks = Layout::default()
+                        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
+                        .direction(Direction::Horizontal)
+                        .split(chunks[1]);
+                    draw_actor_count_chart(f, tab, chunks[0]);
+                    draw_cluster_status(f, members, chunks[1]);
+                } else {
+                    draw_actor_count_chart(f, tab, chunks[1]);
                 }
             }
             draw_actor_tree(f, tab, chunks[0]);
@@ -578,16 +580,12 @@ fn draw_actor_count_chart<B>(f: &mut Frame<B>, tab: &AkkaTab, area: Rect)
 fn draw_cluster_status<B>(f: &mut Frame<B>, v: &Vec<ClusterMember>, area: Rect)
     where B: Backend,
 {
-
-    let items = v.iter().map(|i| Text::raw(&i.node_uid));
-
+    let items = v.iter().map(|i| Text::raw(format!("{}", i)));
     let list = List::new(items)
         .block(Block::default()
             .borders(Borders::ALL)
             .title_style(Style::default().fg(Color::Cyan))
-            .title("Cluster status"))
-        .highlight_style(Style::default().fg(Color::Yellow).modifier(Modifier::BOLD))
-        .highlight_symbol(">");
+            .title("Cluster nodes"));
 
     f.render_widget(list, area);
 }


### PR DESCRIPTION
Hi!

According to @jczuchnowski's guidelines here's PR for introducing akka-cluster status panel showing members from [Akka Management API definition](https://doc.akka.io/docs/akka-management/current/cluster-http-management.html#get-cluster-members-responses).

Here's example (in top right corner):
![](https://iili.io/2x7I29.png)

Additional panel is enabled when `--akka-cluster-status <url>` option is provided, and as it's optional component to akka tab it introduced few `if`s in the code.

It only shows `nodeUid` and `status` as more fields made it obscure in my terminal.

WDYT?